### PR TITLE
[source_ref] add support for named arguments in a Rust format string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
  "serde_json",
  "tree-sitter",
  "tree-sitter-java",
- "tree-sitter-rust",
+ "tree-sitter-rust-orchard",
 ]
 
 [[package]]
@@ -637,10 +637,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
 
 [[package]]
-name = "tree-sitter-rust"
-version = "0.24.0"
+name = "tree-sitter-rust-orchard"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b18034c684a2420722be8b2a91c9c44f2546b631c039edf575ccba8c61be1"
+checksum = "d4c93e825bc354d93bad272d5bb79bc07ce6324d59bbde01fc3829eabfd8e43f"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 tree-sitter = "0.25.3"
-tree-sitter-rust = "0.24.0"
+tree-sitter-rust-orchard = "0.12.0"
 tree-sitter-java = "0.23.5"
 rayon = "1.10.0"
 

--- a/src/call_graph.rs
+++ b/src/call_graph.rs
@@ -85,6 +85,7 @@ fn nope(i: u32) {
             name: String::from("main"),
             text: String::from("foo"),
             matcher: star_regex,
+            args: vec![],
             vars: vec![],
         };
         let star_regex = Regex::new(".*").unwrap();
@@ -95,6 +96,7 @@ fn nope(i: u32) {
             name: String::from("foo"),
             text: String::from("nope"),
             matcher: star_regex,
+            args: vec![],
             vars: vec![],
         };
         assert_eq!(

--- a/src/code_source.rs
+++ b/src/code_source.rs
@@ -36,7 +36,7 @@ impl CodeSource {
 
     pub fn ts_language(&self) -> Language {
         match self.language {
-            SourceLanguage::Rust => tree_sitter_rust::LANGUAGE.into(),
+            SourceLanguage::Rust => tree_sitter_rust_orchard::LANGUAGE.into(),
             SourceLanguage::Java => tree_sitter_java::LANGUAGE.into(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod source_query;
 mod source_ref;
 
 // TODO: doesn't need to be exposed if we can clean up the arguments to do_mapping
+use crate::source_ref::FormatArgument;
 pub use call_graph::CallGraph;
 use call_graph::Edge;
 pub use code_source::CodeSource;
@@ -36,7 +37,7 @@ impl Default for Filter {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 enum SourceLanguage {
     Rust,
     Java,
@@ -51,10 +52,10 @@ impl SourceLanguage {
             SourceLanguage::Rust => {
                 // XXX: assumes it's a debug macro
                 r#"
-                    (macro_invocation macro: (identifier) @macro-name
+                    (macro_invocation macro: (identifier)
                         (token_tree
-                            (string_literal) @log (identifier)* @arguments
-                        ) (#eq? @macro-name "debug")
+                            (string_literal) @log
+                        )
                     )
                 "#
             }
@@ -101,6 +102,16 @@ pub struct LogRef<'a> {
     details: Option<LogDetails<'a>>,
 }
 
+impl<'a> LogRef<'a> {
+    pub fn body(self) -> &'a str {
+        if let Some(LogDetails { body: Some(s), .. }) = self.details {
+            s
+        } else {
+            self.line
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq)]
 struct LogDetails<'a> {
     file: Option<&'a str>,
@@ -133,7 +144,7 @@ impl<'a> LogRef<'a> {
 pub fn link_to_source<'a>(log_ref: &LogRef, src_refs: &'a [SourceRef]) -> Option<&'a SourceRef> {
     src_refs
         .iter()
-        .find(|&source_ref| source_ref.captures(log_ref.line).is_some())
+        .find(|&source_ref| source_ref.captures(log_ref.body()).is_some())
 }
 
 pub fn lookup_source<'a>(
@@ -141,7 +152,7 @@ pub fn lookup_source<'a>(
     log_format: &LogFormat,
     src_refs: &'a [SourceRef],
 ) -> Option<&'a SourceRef> {
-    let captures = log_format.captures(log_ref.line);
+    let captures = log_format.captures(log_ref.body());
     let file_name = captures.name("file").map_or("", |m| m.as_str());
     let line_no: usize = captures
         .name("line")
@@ -163,14 +174,21 @@ pub fn extract_variables<'a>(
         Some(details) => details.body.unwrap_or(log_ref.line),
         None => log_ref.line,
     };
-    if !src_ref.vars.is_empty() {
-        if let Some(captures) = src_ref.captures(line) {
-            for i in 0..captures.len() - 1 {
-                variables.insert(
-                    src_ref.vars[i].to_string(),
-                    captures.get(i + 1).unwrap().as_str().to_string(),
-                );
-            }
+    if let Some(captures) = src_ref.captures(line) {
+        for (index, (cap, placeholder)) in
+            std::iter::zip(captures.iter().skip(1), src_ref.args.iter()).enumerate()
+        {
+            let key = match placeholder {
+                FormatArgument::Named(name) => name.clone(),
+                FormatArgument::Positional(pos) => src_ref
+                    .vars
+                    .get(*pos)
+                    .map(|s| s.as_str())
+                    .unwrap_or("<unknown>")
+                    .to_string(),
+                FormatArgument::Placeholder => src_ref.vars[index].to_string(),
+            };
+            variables.insert(key, cap.unwrap().as_str().to_string());
         }
     }
 
@@ -178,7 +196,7 @@ pub fn extract_variables<'a>(
 }
 
 pub fn filter_log(buffer: &str, filter: Filter, log_format: Option<String>) -> Vec<LogRef> {
-    let log_format = LogFormat::new(log_format);
+    let log_format = log_format.map(LogFormat::new);
     buffer
         .lines()
         .enumerate()
@@ -200,8 +218,10 @@ pub fn do_mappings<'a>(
     sources: &str,
     log_format: Option<String>,
 ) -> Vec<LogMapping<'a>> {
-    let log_format = LogFormat::new(log_format);
-    let source_filter = log_format.clone().map(|f| f.build_src_filter(&log_refs));
+    let log_format = log_format.map(LogFormat::new);
+    let source_filter = log_format
+        .clone()
+        .and_then(|f| f.build_src_filter(&log_refs));
     let mut sources = CodeSource::find_code(sources, source_filter);
     let src_logs = extract_logging(&mut sources);
     let call_graph = CallGraph::new(&mut sources);
@@ -302,7 +322,7 @@ pub fn extract_logging(sources: &mut [CodeSource]) -> Vec<SourceRef> {
                     {
                         let length = matched.len() - 1;
                         let prior_result: &mut SourceRef = matched.get_mut(length).unwrap();
-                        prior_result.vars.push(text);
+                        prior_result.vars.push(text.trim().to_string());
                     }
                 }
                 _ => println!("ignoring {}", result.kind),
@@ -379,8 +399,12 @@ fn foo(i: u32) {
     nope(i);
 }
 
-fn nope(i: u32) {
-    debug!("this won't match i={}", i);
+fn nope(i: u32, j: i32) {
+    debug!("this won't match i={}; j={}", i, j);
+}
+
+fn namedarg(name: &str) {
+    debug!("Hello, {name}!");
 }
     "#;
 
@@ -388,7 +412,7 @@ fn nope(i: u32) {
     fn test_extract_logging() {
         let code = CodeSource::new(PathBuf::from("in-mem.rs"), Box::new(TEST_SOURCE.as_bytes()));
         let src_refs = extract_logging(&mut [code]);
-        assert_eq!(src_refs.len(), 2);
+        assert_eq!(src_refs.len(), 3);
         let first = &src_refs[0];
         assert_eq!(first.line_no, 7);
         assert_eq!(first.column, 11);
@@ -400,39 +424,56 @@ fn nope(i: u32) {
         assert_eq!(second.line_no, 18);
         assert_eq!(second.column, 11);
         assert_eq!(second.name, "nope");
-        assert_eq!(second.text, "\"this won't match i={}\"");
+        assert_eq!(second.text, "\"this won't match i={}; j={}\"");
         assert_eq!(second.vars[0], "i");
     }
 
     #[test]
     fn test_link_to_source() {
-        let log_ref =
-            LogRef::new("[2024-02-15T03:46:44Z DEBUG stack] you're only as funky as your last cut");
+        let lf = LogFormat::new(
+            r#"^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z \w+ \w+\]\s+(?<body>.*)"#.to_string(),
+        );
+        let log_ref = LogRef::with_format(
+            "[2024-05-09T19:58:53Z DEBUG main] you're only as funky as your last cut",
+            lf,
+        );
         let code = CodeSource::new(PathBuf::from("in-mem.rs"), Box::new(TEST_SOURCE.as_bytes()));
         let src_refs = extract_logging(&mut [code]);
-        assert_eq!(src_refs.len(), 2);
+        assert_eq!(src_refs.len(), 3);
         let result = link_to_source(&log_ref, &src_refs);
         assert!(ptr::eq(result.unwrap(), &src_refs[0]));
     }
 
     #[test]
     fn test_link_to_source_no_matches() {
-        let log_ref = LogRef::new("[2024-02-26T03:44:40Z DEBUG stack] nope!");
+        let log_ref = LogRef::new("nope!");
         let code = CodeSource::new(PathBuf::from("in-mem.rs"), Box::new(TEST_SOURCE.as_bytes()));
         let src_refs = extract_logging(&mut [code]);
-        assert_eq!(src_refs.len(), 2);
+        assert_eq!(src_refs.len(), 3);
         let result = link_to_source(&log_ref, &src_refs);
         assert!(result.is_none());
     }
 
     #[test]
     fn test_extract_variables() {
-        let log_ref = LogRef::new("[2024-02-15T03:46:44Z DEBUG nope] this won't match i=1");
+        let log_ref = LogRef::new("this won't match i=1; j=2");
         let code = CodeSource::new(PathBuf::from("in-mem.rs"), Box::new(TEST_SOURCE.as_bytes()));
         let src_refs = extract_logging(&mut [code]);
-        assert_eq!(src_refs.len(), 2);
+        assert_eq!(src_refs.len(), 3);
         let vars = extract_variables(log_ref, &src_refs[1]);
+        assert_eq!(vars.len(), 2);
         assert_eq!(vars.get("i").map(|val| val.as_str()), Some("1"));
+        assert_eq!(vars.get("j").map(|val| val.as_str()), Some("2"));
+    }
+
+    #[test]
+    fn test_extract_named() {
+        let log_ref = LogRef::new("Hello, Tim!");
+        let code = CodeSource::new(PathBuf::from("in-mem.rs"), Box::new(TEST_SOURCE.as_bytes()));
+        let src_refs = extract_logging(&mut [code]);
+        assert_eq!(src_refs.len(), 3);
+        let vars = extract_variables(log_ref, &src_refs[2]);
+        assert_eq!(vars.get("name").map(|val| val.as_str()), Some("Tim"));
     }
 
     const TEST_PUNC_SRC: &str = r#"""
@@ -452,8 +493,7 @@ fn nope(i: u32) {
         let regex = String::from(
             r"^(?<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) (?<level>\w+)\s+ (?<file>[\w$.]+):(?<line>\d+) - (?<body>.*)$",
         );
-        let log_format = Some(regex);
-        let log_format = LogFormat::new(log_format).unwrap();
+        let log_format = LogFormat::new(regex);
         let log_ref = LogRef::with_format(
             "2025-04-10 22:12:52 INFO  JvmPauseMonitor:146 - JvmPauseMonitor-n0: Started",
             log_format,
@@ -487,6 +527,7 @@ fn nope(i: u32) {
             name: String::from("main"),
             text: String::from("foo"),
             matcher: star_regex,
+            args: vec![],
             vars: vec![],
         };
         let star_regex = Regex::new(".*").unwrap();
@@ -497,6 +538,7 @@ fn nope(i: u32) {
             name: String::from("foo"),
             text: String::from("nope"),
             matcher: star_regex,
+            args: vec![],
             vars: vec![],
         };
         assert_eq!(paths, vec![vec![foo_2_nope, main_2_foo]])

--- a/src/log_format.rs
+++ b/src/log_format.rs
@@ -8,11 +8,11 @@ pub struct LogFormat {
 }
 
 impl LogFormat {
-    pub fn new(format: Option<String>) -> Option<LogFormat> {
-        format.map(|fmt| LogFormat {
+    pub fn new(format: String) -> LogFormat {
+        LogFormat {
             // TODO handle more gracefully if wrong format
-            regex: Regex::new(&fmt).unwrap(),
-        })
+            regex: Regex::new(&format).unwrap(),
+        }
     }
 
     pub fn has_src_hint(self: LogFormat) -> bool {
@@ -20,7 +20,7 @@ impl LogFormat {
         flatten.any(|name| name == "line") && flatten.any(|name| name == "file")
     }
 
-    pub fn build_src_filter(&self, log_refs: &Vec<LogRef>) -> Vec<String> {
+    pub fn build_src_filter(&self, log_refs: &Vec<LogRef>) -> Option<Vec<String>> {
         let mut results = Vec::new();
         for log_ref in log_refs {
             let captures = self.captures(log_ref.line);
@@ -28,7 +28,7 @@ impl LogFormat {
                 results.push(file_match.as_str().to_string());
             }
         }
-        results
+        (!results.is_empty()).then_some(results)
     }
 
     pub fn captures<'a>(&self, line: &'a str) -> Captures<'a> {

--- a/tests/snapshots/test_java__basic_unix.snap
+++ b/tests/snapshots/test_java__basic_unix.snap
@@ -7,13 +7,15 @@ info:
     - tests/java/Basic.java
     - "-l"
     - tests/resources/java/basic.log
+    - "-f"
+    - "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} \\w+ \\w+ \\w+: (?<body>.*)"
 ---
 success: true
 exit_code: 0
 ----- stdout -----
-{"srcRef":{"sourcePath":"tests/java/Basic.java","lineNumber":18,"column":16,"name":"main","text":"\"Hello from main\"","vars":[]},"variables":{},"stack":[]}
-{"srcRef":{"sourcePath":"tests/java/Basic.java","lineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","vars":["i"]},"variables":{"i":"0"},"stack":[]}
-{"srcRef":{"sourcePath":"tests/java/Basic.java","lineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","vars":["i"]},"variables":{"i":"1"},"stack":[]}
-{"srcRef":{"sourcePath":"tests/java/Basic.java","lineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","vars":["i"]},"variables":{"i":"2"},"stack":[]}
+{"srcRef":{"sourcePath":"tests/java/Basic.java","lineNumber":18,"column":16,"name":"main","text":"\"Hello from main\"","args":[],"vars":[]},"variables":{},"stack":[]}
+{"srcRef":{"sourcePath":"tests/java/Basic.java","lineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","args":["Placeholder"],"vars":["i"]},"variables":{"i":"0"},"stack":[]}
+{"srcRef":{"sourcePath":"tests/java/Basic.java","lineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","args":["Placeholder"],"vars":["i"]},"variables":{"i":"1"},"stack":[]}
+{"srcRef":{"sourcePath":"tests/java/Basic.java","lineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","args":["Placeholder"],"vars":["i"]},"variables":{"i":"2"},"stack":[]}
 
 ----- stderr -----

--- a/tests/snapshots/test_java__basic_with_log_format_unix.snap
+++ b/tests/snapshots/test_java__basic_with_log_format_unix.snap
@@ -13,9 +13,9 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-{"srcRef":{"sourcePath":"tests/java/BasicWithCustom.java","lineNumber":15,"column":16,"name":"main","text":"\"Hello from main\"","vars":[]},"variables":{},"stack":[]}
-{"srcRef":{"sourcePath":"tests/java/BasicWithCustom.java","lineNumber":22,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","vars":["i"]},"variables":{"i":"0"},"stack":[]}
-{"srcRef":{"sourcePath":"tests/java/BasicWithCustom.java","lineNumber":22,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","vars":["i"]},"variables":{"i":"1"},"stack":[]}
-{"srcRef":{"sourcePath":"tests/java/BasicWithCustom.java","lineNumber":22,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","vars":["i"]},"variables":{"i":"2"},"stack":[]}
+{"srcRef":{"sourcePath":"tests/java/BasicWithCustom.java","lineNumber":15,"column":16,"name":"main","text":"\"Hello from main\"","args":[],"vars":[]},"variables":{},"stack":[]}
+{"srcRef":{"sourcePath":"tests/java/BasicWithCustom.java","lineNumber":22,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","args":["Placeholder"],"vars":["i"]},"variables":{"i":"0"},"stack":[]}
+{"srcRef":{"sourcePath":"tests/java/BasicWithCustom.java","lineNumber":22,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","args":["Placeholder"],"vars":["i"]},"variables":{"i":"1"},"stack":[]}
+{"srcRef":{"sourcePath":"tests/java/BasicWithCustom.java","lineNumber":22,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","args":["Placeholder"],"vars":["i"]},"variables":{"i":"2"},"stack":[]}
 
 ----- stderr -----

--- a/tests/snapshots/test_java__basic_with_log_unix.snap
+++ b/tests/snapshots/test_java__basic_with_log_unix.snap
@@ -7,13 +7,15 @@ info:
     - tests/java/BasicWithLog.java
     - "-l"
     - tests/resources/java/basic.log
+    - "-f"
+    - "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} \\w+ \\w+ \\w+: (?<body>.*)"
 ---
 success: true
 exit_code: 0
 ----- stdout -----
-{"srcRef":{"sourcePath":"tests/java/BasicWithLog.java","lineNumber":18,"column":13,"name":"main","text":"\"Hello from main\"","vars":[]},"variables":{},"stack":[]}
-{"srcRef":{"sourcePath":"tests/java/BasicWithLog.java","lineNumber":25,"column":17,"name":"foo","text":"\"Hello from foo i=\\{i}\"","vars":["i"]},"variables":{"i":"0"},"stack":[]}
-{"srcRef":{"sourcePath":"tests/java/BasicWithLog.java","lineNumber":25,"column":17,"name":"foo","text":"\"Hello from foo i=\\{i}\"","vars":["i"]},"variables":{"i":"1"},"stack":[]}
-{"srcRef":{"sourcePath":"tests/java/BasicWithLog.java","lineNumber":25,"column":17,"name":"foo","text":"\"Hello from foo i=\\{i}\"","vars":["i"]},"variables":{"i":"2"},"stack":[]}
+{"srcRef":{"sourcePath":"tests/java/BasicWithLog.java","lineNumber":18,"column":13,"name":"main","text":"\"Hello from main\"","args":[],"vars":[]},"variables":{},"stack":[]}
+{"srcRef":{"sourcePath":"tests/java/BasicWithLog.java","lineNumber":25,"column":17,"name":"foo","text":"\"Hello from foo i=\\{i}\"","args":["Placeholder"],"vars":["i"]},"variables":{"i":"0"},"stack":[]}
+{"srcRef":{"sourcePath":"tests/java/BasicWithLog.java","lineNumber":25,"column":17,"name":"foo","text":"\"Hello from foo i=\\{i}\"","args":["Placeholder"],"vars":["i"]},"variables":{"i":"1"},"stack":[]}
+{"srcRef":{"sourcePath":"tests/java/BasicWithLog.java","lineNumber":25,"column":17,"name":"foo","text":"\"Hello from foo i=\\{i}\"","args":["Placeholder"],"vars":["i"]},"variables":{"i":"2"},"stack":[]}
 
 ----- stderr -----

--- a/tests/snapshots/test_java__basic_with_upper_unix.snap
+++ b/tests/snapshots/test_java__basic_with_upper_unix.snap
@@ -7,13 +7,15 @@ info:
     - tests/java/BasicWithUpper.java
     - "-l"
     - tests/resources/java/basic.log
+    - "-f"
+    - "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} \\w+ \\w+ \\w+: (?<body>.*)"
 ---
 success: true
 exit_code: 0
 ----- stdout -----
-{"srcRef":{"sourcePath":"tests/java/BasicWithUpper.java","lineNumber":18,"column":16,"name":"main","text":"\"Hello from main\"","vars":[]},"variables":{},"stack":[]}
-{"srcRef":{"sourcePath":"tests/java/BasicWithUpper.java","lineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","vars":["i"]},"variables":{"i":"0"},"stack":[]}
-{"srcRef":{"sourcePath":"tests/java/BasicWithUpper.java","lineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","vars":["i"]},"variables":{"i":"1"},"stack":[]}
-{"srcRef":{"sourcePath":"tests/java/BasicWithUpper.java","lineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","vars":["i"]},"variables":{"i":"2"},"stack":[]}
+{"srcRef":{"sourcePath":"tests/java/BasicWithUpper.java","lineNumber":18,"column":16,"name":"main","text":"\"Hello from main\"","args":[],"vars":[]},"variables":{},"stack":[]}
+{"srcRef":{"sourcePath":"tests/java/BasicWithUpper.java","lineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","args":["Placeholder"],"vars":["i"]},"variables":{"i":"0"},"stack":[]}
+{"srcRef":{"sourcePath":"tests/java/BasicWithUpper.java","lineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","args":["Placeholder"],"vars":["i"]},"variables":{"i":"1"},"stack":[]}
+{"srcRef":{"sourcePath":"tests/java/BasicWithUpper.java","lineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","args":["Placeholder"],"vars":["i"]},"variables":{"i":"2"},"stack":[]}
 
 ----- stderr -----

--- a/tests/snapshots/test_rust__basic_unix.snap
+++ b/tests/snapshots/test_rust__basic_unix.snap
@@ -7,13 +7,15 @@ info:
     - examples/basic.rs
     - "-l"
     - tests/resources/rust/basic.log
+    - "-f"
+    - "\\[\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z \\w+ \\w+\\]\\s+(?<body>.*)"
 ---
 success: true
 exit_code: 0
 ----- stdout -----
-{"srcRef":{"sourcePath":"examples/basic.rs","lineNumber":6,"column":11,"name":"main","text":"\"Hello from main\"","vars":[]},"variables":{},"stack":[[{"sourcePath":"examples/basic.rs","lineNumber":8,"column":8,"name":"main","text":"foo","vars":[]}]]}
-{"srcRef":{"sourcePath":"examples/basic.rs","lineNumber":13,"column":11,"name":"foo","text":"\"Hello from foo i={}\"","vars":["i"]},"variables":{"i":"0"},"stack":[[{"sourcePath":"examples/basic.rs","lineNumber":8,"column":8,"name":"main","text":"foo","vars":[]}]]}
-{"srcRef":{"sourcePath":"examples/basic.rs","lineNumber":13,"column":11,"name":"foo","text":"\"Hello from foo i={}\"","vars":["i"]},"variables":{"i":"1"},"stack":[[{"sourcePath":"examples/basic.rs","lineNumber":8,"column":8,"name":"main","text":"foo","vars":[]}]]}
-{"srcRef":{"sourcePath":"examples/basic.rs","lineNumber":13,"column":11,"name":"foo","text":"\"Hello from foo i={}\"","vars":["i"]},"variables":{"i":"2"},"stack":[[{"sourcePath":"examples/basic.rs","lineNumber":8,"column":8,"name":"main","text":"foo","vars":[]}]]}
+{"srcRef":{"sourcePath":"examples/basic.rs","lineNumber":6,"column":11,"name":"main","text":"\"Hello from main\"","args":[],"vars":[]},"variables":{},"stack":[[{"sourcePath":"examples/basic.rs","lineNumber":8,"column":8,"name":"main","text":"foo","args":[],"vars":[]}]]}
+{"srcRef":{"sourcePath":"examples/basic.rs","lineNumber":13,"column":11,"name":"foo","text":"\"Hello from foo i={}\"","args":["Placeholder"],"vars":["i"]},"variables":{"i":"0"},"stack":[[{"sourcePath":"examples/basic.rs","lineNumber":8,"column":8,"name":"main","text":"foo","args":[],"vars":[]}]]}
+{"srcRef":{"sourcePath":"examples/basic.rs","lineNumber":13,"column":11,"name":"foo","text":"\"Hello from foo i={}\"","args":["Placeholder"],"vars":["i"]},"variables":{"i":"1"},"stack":[[{"sourcePath":"examples/basic.rs","lineNumber":8,"column":8,"name":"main","text":"foo","args":[],"vars":[]}]]}
+{"srcRef":{"sourcePath":"examples/basic.rs","lineNumber":13,"column":11,"name":"foo","text":"\"Hello from foo i={}\"","args":["Placeholder"],"vars":["i"]},"variables":{"i":"2"},"stack":[[{"sourcePath":"examples/basic.rs","lineNumber":8,"column":8,"name":"main","text":"foo","args":[],"vars":[]}]]}
 
 ----- stderr -----

--- a/tests/snapshots/test_rust__stack_unix.snap
+++ b/tests/snapshots/test_rust__stack_unix.snap
@@ -7,12 +7,14 @@ info:
     - examples/stack.rs
     - "-l"
     - tests/resources/rust/stack.log
+    - "-f"
+    - "\\[\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z \\w+ \\w+\\]\\s+(?<body>.*)"
     - "-s"
     - "1"
 ---
 success: true
 exit_code: 0
 ----- stdout -----
-{"srcRef":{"sourcePath":"examples/stack.rs","lineNumber":15,"column":11,"name":"b","text":"\"Hello from b\"","vars":[]},"variables":{},"stack":[[{"sourcePath":"examples/stack.rs","lineNumber":11,"column":4,"name":"a","text":"b","vars":[]},{"sourcePath":"examples/stack.rs","lineNumber":7,"column":4,"name":"main","text":"a","vars":[]}]]}
+{"srcRef":{"sourcePath":"examples/stack.rs","lineNumber":15,"column":11,"name":"b","text":"\"Hello from b\"","args":[],"vars":[]},"variables":{},"stack":[[{"sourcePath":"examples/stack.rs","lineNumber":11,"column":4,"name":"a","text":"b","args":[],"vars":[]},{"sourcePath":"examples/stack.rs","lineNumber":7,"column":4,"name":"main","text":"a","args":[],"vars":[]}]]}
 
 ----- stderr -----

--- a/tests/test_java.rs
+++ b/tests/test_java.rs
@@ -21,7 +21,9 @@ fn basic() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("-d")
         .arg(basic_source.to_str().expect("test case source code exists"))
         .arg("-l")
-        .arg(basic_log.to_str().expect("test case log exists"));
+        .arg(basic_log.to_str().expect("test case log exists"))
+        .arg("-f")
+        .arg(r#"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \w+ \w+ \w+: (?<body>.*)"#);
 
     let snapshot_name = format!("basic_{}", get_platform_suffix());
     assert_cmd_snapshot!(snapshot_name, cmd);
@@ -39,7 +41,9 @@ fn basic_with_log() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("-d")
         .arg(basic_source.to_str().expect("test case source code exists"))
         .arg("-l")
-        .arg(basic_log.to_str().expect("test case log exists"));
+        .arg(basic_log.to_str().expect("test case log exists"))
+        .arg("-f")
+        .arg(r#"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \w+ \w+ \w+: (?<body>.*)"#);
 
     let snapshot_name = format!("basic_with_log_{}", get_platform_suffix());
     assert_cmd_snapshot!(snapshot_name, cmd);
@@ -57,7 +61,9 @@ fn basic_with_upper() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("-d")
         .arg(basic_source.to_str().expect("test case source code exists"))
         .arg("-l")
-        .arg(basic_log.to_str().expect("test case log exists"));
+        .arg(basic_log.to_str().expect("test case log exists"))
+        .arg("-f")
+        .arg(r#"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \w+ \w+ \w+: (?<body>.*)"#);
 
     let snapshot_name = format!("basic_with_upper_{}", get_platform_suffix());
     assert_cmd_snapshot!(snapshot_name, cmd);

--- a/tests/test_rust.rs
+++ b/tests/test_rust.rs
@@ -21,7 +21,9 @@ fn basic() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("-d")
         .arg(source.to_str().expect("test case path is valid"))
         .arg("-l")
-        .arg(log.to_str().expect("test case log path is valid"));
+        .arg(log.to_str().expect("test case log path is valid"))
+        .arg("-f")
+        .arg(r#"\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z \w+ \w+\]\s+(?<body>.*)"#);
 
     let snapshot_name = format!("basic_{}", get_platform_suffix());
     assert_cmd_snapshot!(snapshot_name, cmd);
@@ -41,6 +43,8 @@ fn stack() -> Result<(), Box<dyn std::error::Error>> {
         .arg(source.to_str().expect("test case path is valid"))
         .arg("-l")
         .arg(log.to_str().expect("test case log path is valid"))
+        .arg("-f")
+        .arg(r#"\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z \w+ \w+\]\s+(?<body>.*)"#)
         .arg("-s")
         .arg("1");
 


### PR DESCRIPTION
(XXX I haven't updated the windows snapshots...)

A simple first project, adding support for named arguments in a Rust format string.  The SourceRef now contains more detail about the placeholders in the format string since that is where the name comes from.  (The Java stuff works because tree-sitter understands the StringTemplate magic)

Files:
* Cargo.toml: Try using tree-sitter-rust-orchard which seems to be more up-to-date than the main one.
* lib.rs:
  - Capture all strings in a macro, to make sure we don't miss anything.
  - Add body() method to LogRef to make it easy to get the string to run the regex over.
  - lookup_source() needs to pull expressions from the placeholder or the arguments.
* log_format.rs: Make build_src_filter() return an Option that is None if there are no filters.
* source_query.rs: Extract the expressions used in the macro since tree-sitter is not going to do it for us.
* source_ref.rs: Use a language-specific regex for processing format strings.