### PR TITLE
[discovery] add a layer to keep track of source tree state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "getrandom"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +407,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,9 +481,11 @@ dependencies = [
  "cc",
  "clap",
  "env_logger",
+ "fs_extra",
  "indicatif",
  "insta",
  "insta-cmd",
+ "itertools",
  "log",
  "miette",
  "rand",
@@ -470,6 +493,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tree-sitter",
  "tree-sitter-cpp",
@@ -806,6 +830,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5.36", features = ["derive"] }
 indicatif = "0.18.0"
+itertools = "0.14.0"
 regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
@@ -29,3 +30,5 @@ insta = { version = "1.43.1", features = ["yaml", "filters"] }
 insta-cmd = "0.6.0"
 log = "0.4.27"
 rand = "0.9.0"
+tempfile = "3.22.0"
+fs_extra = "1.3"

--- a/src/code_source.rs
+++ b/src/code_source.rs
@@ -1,139 +1,39 @@
+use std::io;
 use std::path::{Path, PathBuf};
-use std::{
-    fs::{self, File},
-    io,
-};
-use tree_sitter::Language;
 
+use crate::source_hier::SourceFileInfo;
 use crate::{LogError, SourceLanguage};
 
 pub struct CodeSource {
     pub(crate) filename: String,
-    pub(crate) language: SourceLanguage,
+    pub(crate) info: SourceFileInfo,
     pub(crate) buffer: String,
 }
 
 impl CodeSource {
-    pub fn new(path: &Path, mut input: Box<dyn io::Read>) -> Result<CodeSource, LogError> {
-        let language = match path.extension() {
-            Some(ext) => match ext.to_str().unwrap() {
-                "rs" => SourceLanguage::Rust,
-                "java" => SourceLanguage::Java,
-                "h" | "hh" | "hpp" | "cc" | "cpp" => SourceLanguage::Cpp,
-                _ => panic!("Unsupported language"),
-            },
-            None => panic!("No extension"),
-        };
+    pub fn new<I>(path: &Path, info: SourceFileInfo, mut input: I) -> Result<CodeSource, LogError>
+    where
+        I: io::Read,
+    {
         let mut buffer = String::new();
         match input.read_to_string(&mut buffer) {
             Ok(_) => Ok(CodeSource {
-                language,
                 filename: path.to_string_lossy().to_string(),
+                info,
                 buffer,
             }),
             Err(err) => Err(LogError::CannotReadSourceFile {
                 path: PathBuf::from(path),
-                source: err,
+                source: err.into(),
             }),
         }
     }
 
-    pub fn ts_language(&self) -> Language {
-        match self.language {
-            SourceLanguage::Rust => tree_sitter_rust_orchard::LANGUAGE.into(),
-            SourceLanguage::Java => tree_sitter_java::LANGUAGE.into(),
-            SourceLanguage::Cpp => tree_sitter_cpp::LANGUAGE.into(),
+    pub fn from_string(path: &Path, input: &str) -> CodeSource {
+        CodeSource {
+            filename: path.to_string_lossy().to_string(),
+            info: SourceFileInfo::new(SourceLanguage::from_path(path).unwrap()),
+            buffer: input.to_string(),
         }
     }
-
-    pub fn find_code(path: &Path, filter: Option<Vec<String>>) -> (Vec<CodeSource>, Vec<LogError>) {
-        let mut srcs = vec![];
-        let mut errs = vec![];
-        match fs::metadata(path) {
-            Ok(meta) => {
-                if meta.is_file() {
-                    try_add_file(path, &mut srcs, &mut errs, &filter);
-                } else {
-                    if let Err(err) = walk_dir(path, &mut srcs, &mut errs, &filter) {
-                        errs.push(err);
-                    }
-                }
-            }
-            Err(err) => errs.push(LogError::CannotReadSourceFile {
-                path: PathBuf::from(path),
-                source: err,
-            }),
-        }
-        (srcs, errs)
-    }
-}
-
-const SUPPORTED_EXTS: &[&str] = &["java", "rs", "h", "hh", "hpp", "cc", "cpp"];
-
-fn try_add_file(
-    path: &Path,
-    srcs: &mut Vec<CodeSource>,
-    errs: &mut Vec<LogError>,
-    filter: &Option<Vec<String>>,
-) {
-    if let Some(filter_list) = filter {
-        if let Some(file_name) = path.file_name() {
-            if !filter_list
-                .iter()
-                .any(|f| file_name.to_string_lossy().contains(f))
-            {
-                return;
-            }
-        }
-    };
-
-    if let Some(ext) = path.extension() {
-        if SUPPORTED_EXTS.iter().any(|&supported| supported == ext) {
-            match File::open(path) {
-                Ok(file) => {
-                    let input = Box::new(file);
-                    match CodeSource::new(path, input) {
-                        Ok(code) => srcs.push(code),
-                        Err(err) => errs.push(err),
-                    }
-                }
-                Err(err) => errs.push(LogError::CannotReadSourceFile {
-                    path: PathBuf::from(path),
-                    source: err,
-                })
-            }
-        }
-    }
-}
-
-fn walk_dir(
-    dir: &Path,
-    srcs: &mut Vec<CodeSource>,
-    errs: &mut Vec<LogError>,
-    filter: &Option<Vec<String>>,
-) -> Result<(), LogError> {
-    match fs::read_dir(dir) {
-        Ok(entries) => {
-            for entry in entries {
-                let entry = entry.map_err(|source| LogError::CannotAccessPath {
-                    path: PathBuf::from(dir),
-                    source,
-                })?;
-                let path = entry.path();
-                let metadata = fs::metadata(&path).map_err(|source| LogError::CannotAccessPath {
-                    path: PathBuf::from(dir),
-                    source,
-                })?;
-                if metadata.is_file() {
-                    try_add_file(&path, srcs, errs, filter);
-                } else if metadata.is_dir() {
-                    if let Err(err) = walk_dir(&path, srcs, errs, filter) {
-                        errs.push(err);
-                    }
-                }
-            }
-        }
-        Err(_) => {}
-    }
-    Ok(())
 }

--- a/src/snapshots/log2src__source_hier__test__with_resources_dir-2.snap
+++ b/src/snapshots/log2src__source_hier__test__with_resources_dir-2.snap
@@ -1,0 +1,5 @@
+---
+source: src/source_hier.rs
+expression: no_events
+---
+[]

--- a/src/snapshots/log2src__source_hier__test__with_resources_dir-3.snap
+++ b/src/snapshots/log2src__source_hier__test__with_resources_dir-3.snap
@@ -1,0 +1,18 @@
+---
+source: src/source_hier.rs
+expression: new_and_updated_events
+---
+- DeletedFile:
+    - Basic.java
+    - 1
+- DeletedFile:
+    - test_java.rs
+    - 5
+- NewFile:
+    - Basic.java
+    - language: Java
+      id: 7
+- NewFile:
+    - new.rs
+    - language: Rust
+      id: 8

--- a/src/snapshots/log2src__source_hier__test__with_resources_dir-4.snap
+++ b/src/snapshots/log2src__source_hier__test__with_resources_dir-4.snap
@@ -1,0 +1,16 @@
+---
+source: src/source_hier.rs
+expression: deleted_dir_events
+---
+- DeletedFile:
+    - BasicWithUpper.java
+    - 4
+- DeletedFile:
+    - BasicWithLog.java
+    - 3
+- DeletedFile:
+    - BasicWithCustom.java
+    - 2
+- DeletedFile:
+    - Basic.java
+    - 7

--- a/src/snapshots/log2src__source_hier__test__with_resources_dir.snap
+++ b/src/snapshots/log2src__source_hier__test__with_resources_dir.snap
@@ -1,0 +1,32 @@
+---
+source: src/source_hier.rs
+expression: events
+---
+- NewFile:
+    - test_rust.rs
+    - language: Rust
+      id: 6
+- NewFile:
+    - test_java.rs
+    - language: Rust
+      id: 5
+- NewFile:
+    - BasicWithUpper.java
+    - language: Java
+      id: 4
+- NewFile:
+    - BasicWithLog.java
+    - language: Java
+      id: 3
+- NewFile:
+    - BasicWithCustom.java
+    - language: Java
+      id: 2
+- NewFile:
+    - Basic.java
+    - language: Java
+      id: 1
+- NewFile:
+    - common_settings.rs
+    - language: Rust
+      id: 0

--- a/src/source_hier.rs
+++ b/src/source_hier.rs
@@ -1,0 +1,538 @@
+use crate::{LogError, SourceLanguage};
+use serde::Serialize;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+use std::{fs, io};
+
+/// Result of a shallow check of a file system path.  Mainly interested in getting a directory
+/// listing without descending into the child trees.
+enum ShallowCheckResult {
+    File {
+        latest_modified_time: SystemTime,
+    },
+    Directory {
+        latest_entries: BTreeMap<OsString, Result<fs::Metadata, io::Error>>,
+    },
+    Error,
+}
+
+/// A unique identifier for a file that can be used instead of retaining the full path.
+#[derive(Copy, Clone, Debug, Serialize, Hash, Eq, PartialEq)]
+pub struct SourceFileID(usize);
+
+/// A summary of a source code file
+#[derive(Copy, Clone, Debug, Serialize)]
+pub struct SourceFileInfo {
+    pub language: SourceLanguage,
+    pub id: SourceFileID,
+}
+
+impl SourceFileInfo {
+    // Allow the ID counter to be set for a thread from the SourceHierTree.
+    thread_local! {
+        static NEXT_ID: RefCell<usize> = RefCell::new(0);
+    }
+
+    pub fn new(language: SourceLanguage) -> Self {
+        Self::NEXT_ID.with(|next_id| {
+            let mut inner = next_id.borrow_mut();
+            let id = SourceFileID(*inner);
+            *inner += 1;
+            Self { language, id }
+        })
+    }
+}
+
+/// The type of content in a node in the source hierarchy
+#[derive(Debug)]
+pub enum SourceHierContent {
+    File {
+        info: SourceFileInfo,
+        last_modified_time: SystemTime,
+    },
+    UnsupportedFile {},
+    Directory {
+        entries: BTreeMap<OsString, SourceHierNode>,
+    },
+    Error {
+        source: LogError,
+    },
+    Unknown {},
+}
+
+impl SourceHierContent {
+    fn entries_of(
+        path: &Path,
+    ) -> Result<BTreeMap<OsString, Result<fs::Metadata, io::Error>>, io::Error> {
+        Ok(fs::read_dir(path)?
+            .flat_map(|entry| match entry {
+                Ok(entry) => Some((entry.file_name(), entry.metadata())),
+                Err(_err) => None,
+            })
+            .collect())
+    }
+
+    fn from_dir(path: &Path) -> Self {
+        match Self::entries_of(path) {
+            Ok(entries) => Self::Directory {
+                entries: entries
+                    .into_iter()
+                    .map(|(entry_name, meta)| {
+                        (
+                            entry_name.to_os_string(),
+                            SourceHierNode::from_int(&path.join(entry_name), meta),
+                        )
+                    })
+                    .collect(),
+            },
+            Err(err) => Self::Error {
+                source: LogError::CannotAccessPath {
+                    path: path.to_path_buf(),
+                    source: err.into(),
+                },
+            },
+        }
+    }
+
+    fn from(path: &Path, metadata: Result<fs::Metadata, io::Error>) -> Self {
+        match metadata {
+            Ok(meta) => {
+                if meta.is_dir() {
+                    Self::from_dir(path)
+                } else if meta.is_file() {
+                    match SourceLanguage::from_path(&path) {
+                        Some(language) => match meta.modified() {
+                            Ok(last_modified_time) => Self::File {
+                                info: SourceFileInfo::new(language),
+                                last_modified_time,
+                            },
+                            Err(err) => Self::Error {
+                                source: LogError::CannotAccessPath {
+                                    path: path.to_path_buf(),
+                                    source: err.into(),
+                                },
+                            },
+                        },
+                        None => Self::UnsupportedFile {},
+                    }
+                } else {
+                    Self::Unknown {}
+                }
+            }
+            Err(err) => Self::Error {
+                source: LogError::CannotAccessPath {
+                    path: path.to_path_buf(),
+                    source: err.into(),
+                },
+            },
+        }
+    }
+
+    fn shallow_check(
+        path: &Path,
+        metadata: &Result<fs::Metadata, io::Error>,
+    ) -> ShallowCheckResult {
+        match metadata {
+            Ok(meta) => {
+                if meta.is_file() {
+                    match meta.modified() {
+                        Ok(latest_modified_time) => ShallowCheckResult::File {
+                            latest_modified_time,
+                        },
+                        Err(_) => ShallowCheckResult::Error,
+                    }
+                } else if meta.is_dir() {
+                    match Self::entries_of(path) {
+                        Ok(latest_entries) => ShallowCheckResult::Directory { latest_entries },
+                        Err(_) => ShallowCheckResult::Error,
+                    }
+                } else {
+                    ShallowCheckResult::Error
+                }
+            }
+            Err(_) => ShallowCheckResult::Error,
+        }
+    }
+
+    /// Synchronized this content with the current state on the file system.
+    ///
+    /// # Cases
+    /// ## Files
+    /// If a file exists and has the same modified time as the last sync, nothing is done.
+    /// Otherwise, a new content value is created from the file system state and self is
+    /// overwritten with that value.
+    ///
+    /// ## Directories
+    /// A shallow scan of the directory is done to gather file names and metadata.  If files in
+    /// the current state are not found in the shallow scan, ScanEvent::DeletedFile events will
+    /// be added to the "deleted_events" vector.  If files in the current state are in the
+    /// shallow state, they will be synced individually.  If there are files in the shallow scan
+    /// that are not in the current state, they will be instantiated added as children of the
+    /// directory.
+    fn sync_int(
+        &mut self,
+        path: &Path,
+        latest_meta: Result<fs::Metadata, io::Error>,
+        deleted_events: &mut Vec<ScanEvent>,
+    ) -> bool {
+        let latest_content = Self::shallow_check(path, &latest_meta);
+        *self = match self {
+            SourceHierContent::File {
+                last_modified_time,
+                info,
+                ..
+            } => match latest_content {
+                ShallowCheckResult::File {
+                    latest_modified_time,
+                    ..
+                } if *last_modified_time == latest_modified_time => {
+                    return false;
+                }
+                _ => {
+                    deleted_events.push(ScanEvent::DeletedFile(PathBuf::from(path), info.id));
+                    Self::from(path, latest_meta)
+                }
+            },
+            SourceHierContent::Directory { ref mut entries } => match latest_content {
+                ShallowCheckResult::Directory { latest_entries } => {
+                    let mut changed = false;
+                    entries.retain(|name, node| {
+                        let exists = latest_entries.contains_key(name);
+                        if !exists {
+                            node.deleted(path, name, deleted_events);
+                            changed = true;
+                        }
+                        exists
+                    });
+                    let mut new_entries: Vec<(OsString, Result<fs::Metadata, io::Error>)> =
+                        Vec::new();
+                    for (name, meta) in latest_entries {
+                        if let Some(existing_entry) = entries.get_mut(&name) {
+                            existing_entry.sync(&path.join(&name), meta, deleted_events)
+                        } else {
+                            new_entries.push((name, meta));
+                            changed = true;
+                        }
+                    }
+                    new_entries.into_iter().for_each(|(name, meta)| {
+                        let node = SourceHierNode::from_int(&path.join(&name), meta);
+                        entries.insert(name, node);
+                    });
+                    return changed;
+                }
+                _ => Self::from(path, latest_meta),
+            },
+            _ => Self::from(path, latest_meta),
+        };
+        true
+    }
+}
+
+/// A node in the SourceHierTree.  It contains information that is common to all types of content
+/// and the content itself (e.g. file, directory, error, ...).
+#[derive(Debug)]
+pub struct SourceHierNode {
+    pub last_scan_time: Option<SystemTime>,
+    pub content: SourceHierContent,
+}
+
+impl SourceHierNode {
+    fn from_int(path: &Path, metadata: Result<fs::Metadata, io::Error>) -> Self {
+        match metadata {
+            Ok(meta) => {
+                if meta.is_dir() {
+                    Self {
+                        last_scan_time: None,
+                        content: SourceHierContent::from_dir(path),
+                    }
+                } else if meta.is_file() {
+                    match SourceLanguage::from_path(&path) {
+                        Some(language) => match meta.modified() {
+                            Ok(last_modified_time) => Self {
+                                last_scan_time: None,
+                                content: SourceHierContent::File {
+                                    info: SourceFileInfo::new(language),
+                                    last_modified_time,
+                                },
+                            },
+                            Err(err) => Self {
+                                last_scan_time: None,
+                                content: SourceHierContent::Error {
+                                    source: LogError::CannotAccessPath {
+                                        path: path.to_path_buf(),
+                                        source: err.into(),
+                                    },
+                                },
+                            },
+                        },
+                        None => Self {
+                            last_scan_time: None,
+                            content: SourceHierContent::UnsupportedFile {},
+                        },
+                    }
+                } else {
+                    Self {
+                        last_scan_time: None,
+                        content: SourceHierContent::Unknown {},
+                    }
+                }
+            }
+            Err(err) => Self {
+                last_scan_time: None,
+                content: SourceHierContent::Error {
+                    source: LogError::CannotAccessPath {
+                        path: path.to_path_buf(),
+                        source: err.into(),
+                    },
+                },
+            },
+        }
+    }
+
+    /// Create a node with unknown content that will be synced at a later point.
+    fn stub() -> Self {
+        SourceHierNode {
+            last_scan_time: None,
+            content: SourceHierContent::Unknown {},
+        }
+    }
+
+    fn deleted(&self, path: &Path, name: &OsStr, deleted_events: &mut Vec<ScanEvent>) {
+        match &self.content {
+            SourceHierContent::File { info, .. } => {
+                deleted_events.push(ScanEvent::DeletedFile(path.join(name), info.id))
+            }
+            SourceHierContent::UnsupportedFile { .. } => {}
+            SourceHierContent::Directory { entries } => {
+                let dir_path = path.join(name);
+                for (child_name, node) in entries {
+                    node.deleted(&dir_path, &child_name, deleted_events);
+                }
+            }
+            SourceHierContent::Error { .. } => {}
+            SourceHierContent::Unknown { .. } => {}
+        }
+    }
+
+    fn sync(
+        &mut self,
+        path: &Path,
+        meta: Result<fs::Metadata, io::Error>,
+        deleted_events: &mut Vec<ScanEvent>,
+    ) {
+        if self.content.sync_int(path, meta, deleted_events) {
+            self.last_scan_time = None;
+        }
+    }
+}
+
+/// An event when iterating over the value returned by the [`scan()`](SourceHierTree::scan())
+/// method.
+#[derive(Debug, Serialize)]
+pub enum ScanEvent {
+    NewFile(PathBuf, SourceFileInfo),
+    DeletedFile(PathBuf, SourceFileID),
+}
+
+struct TreeCursorMut<'a> {
+    curr_path: PathBuf,
+    curr_node: &'a mut SourceHierNode,
+}
+
+pub struct TreeScanner<'a> {
+    deleted_events: Vec<ScanEvent>,
+    stack: Vec<TreeCursorMut<'a>>,
+}
+
+impl Iterator for TreeScanner<'_> {
+    type Item = ScanEvent;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(event) = self.deleted_events.pop() {
+            return Some(event);
+        }
+        while let Some(cursor) = self.stack.pop() {
+            let last_scan_time = cursor.curr_node.last_scan_time;
+            cursor.curr_node.last_scan_time = Some(SystemTime::now());
+            match &mut cursor.curr_node.content {
+                SourceHierContent::File { info, .. } => match last_scan_time {
+                    Some(_) => {}
+                    _ => return Some(ScanEvent::NewFile(cursor.curr_path, *info)),
+                },
+                SourceHierContent::UnsupportedFile { .. } => {}
+                SourceHierContent::Directory { ref mut entries } => {
+                    for child in entries.iter_mut() {
+                        self.stack.push(TreeCursorMut {
+                            curr_path: cursor.curr_path.join(&child.0),
+                            curr_node: child.1,
+                        });
+                    }
+                }
+                SourceHierContent::Error { .. } => {}
+                SourceHierContent::Unknown {} => {}
+            }
+        }
+        None
+    }
+}
+
+#[derive(Debug, Serialize, Default)]
+pub struct SourceHierStats {
+    pub files: usize,
+    pub unsupported_files: usize,
+    pub directories: usize,
+    pub errors: usize,
+}
+
+/// A SourceHierTree tracks the state of a source code hierarchy.
+#[derive(Debug)]
+pub struct SourceHierTree {
+    pub root_path: PathBuf,
+    pub root_node: SourceHierNode,
+    next_id: usize,
+    deleted_events: Vec<ScanEvent>,
+}
+
+impl SourceHierTree {
+    pub fn from(path: &Path) -> SourceHierTree {
+        SourceHierTree {
+            root_path: path.to_path_buf(),
+            root_node: SourceHierNode::stub(),
+            next_id: 0,
+            deleted_events: Vec::new(),
+        }
+    }
+
+    /// Synchronize the state of this tree with the file system.
+    pub fn sync(&mut self) {
+        SourceFileInfo::NEXT_ID.with(|id_opt| {
+            *id_opt.borrow_mut() = self.next_id;
+        });
+        self.root_node.sync(
+            &self.root_path,
+            fs::metadata(&self.root_path),
+            &mut self.deleted_events,
+        );
+        self.next_id = SourceFileInfo::NEXT_ID.with(|id_opt| *id_opt.borrow());
+    }
+
+    /// Scan the tree for changes that have happened since the last scan.  Changes to the tree
+    /// are introduced by the sync() method.
+    pub fn scan(&'_ mut self) -> TreeScanner<'_> {
+        let deleted_events = std::mem::replace(&mut self.deleted_events, Vec::new());
+        TreeScanner {
+            deleted_events,
+            stack: vec![TreeCursorMut {
+                curr_path: self.root_path.clone(),
+                curr_node: &mut self.root_node,
+            }],
+        }
+    }
+
+    /// Visit every node in the hierarchy, depth-first, calling `f` on each.
+    pub fn visit<F>(&self, mut f: F)
+    where
+        F: FnMut(&SourceHierNode),
+    {
+        fn walk<F>(node: &SourceHierNode, f: &mut F)
+        where
+            F: FnMut(&SourceHierNode),
+        {
+            f(node);
+            if let SourceHierContent::Directory { entries } = &node.content {
+                for child in entries.values() {
+                    walk(child, f);
+                }
+            }
+        }
+        walk(&self.root_node, &mut f);
+    }
+
+    pub fn stats(&self) -> SourceHierStats {
+        let mut retval = SourceHierStats::default();
+
+        self.visit(|node| match node.content {
+            SourceHierContent::File { .. } => retval.files += 1,
+            SourceHierContent::UnsupportedFile { .. } => retval.unsupported_files += 1,
+            SourceHierContent::Directory { .. } => retval.directories += 1,
+            SourceHierContent::Error { .. } => retval.errors += 1,
+            SourceHierContent::Unknown { .. } => {}
+        });
+
+        retval
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::source_hier::{ScanEvent, SourceHierTree};
+    use fs_extra::dir::copy;
+    use fs_extra::dir::CopyOptions;
+    use insta::assert_yaml_snapshot;
+    use std::fs;
+    use std::fs::File;
+    use std::io::Write;
+    use std::ops::Sub;
+    use std::path::Path;
+    use std::path::PathBuf;
+    use std::time::{Duration, SystemTime};
+    use tempfile::{tempdir, TempDir};
+
+    fn setup_test_environment(source_dir: &Path) -> TempDir {
+        let temp_dir = tempdir().expect("Failed to create temporary directory");
+        let dest_path = temp_dir.path().to_path_buf();
+
+        // Copy the source directory content to the temporary directory
+        let mut options = CopyOptions::new();
+        options.overwrite = true; // Overwrite if files exist
+        options.copy_inside = true; // Copy contents of source_dir into dest_path
+
+        copy(source_dir, &dest_path, &options)
+            .expect("Failed to copy source directory to temporary directory");
+
+        temp_dir
+    }
+
+    fn redact_event(event: ScanEvent) -> ScanEvent {
+        match event {
+            ScanEvent::NewFile(path, info) => {
+                ScanEvent::NewFile(path.file_name().unwrap().into(), info)
+            }
+            ScanEvent::DeletedFile(path, id) => {
+                ScanEvent::DeletedFile(path.file_name().unwrap().into(), id)
+            }
+        }
+    }
+
+    #[test]
+    fn test_with_resources_dir() {
+        let tests_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
+        let temp_test_dir = setup_test_environment(&tests_path);
+        let _ = File::open(temp_test_dir.path().join("tests/java/Basic.java"))
+            .unwrap()
+            .set_modified(SystemTime::now().sub(Duration::from_secs(10)));
+        let mut tree = SourceHierTree::from(temp_test_dir.path());
+        tree.sync();
+        let events: Vec<ScanEvent> = tree.scan().map(redact_event).collect();
+        assert_yaml_snapshot!(events);
+        let no_events: Vec<ScanEvent> = tree.scan().map(redact_event).collect();
+        assert_yaml_snapshot!(no_events);
+        let _ = fs::remove_file(temp_test_dir.path().join("tests/test_java.rs"));
+        let _ = File::create(temp_test_dir.path().join("new.rs"))
+            .unwrap()
+            .write("abc".as_bytes());
+        let _ = File::open(temp_test_dir.path().join("tests/java/Basic.java"))
+            .unwrap()
+            .set_modified(SystemTime::now());
+        tree.sync();
+        let new_and_updated_events: Vec<ScanEvent> = tree.scan().map(redact_event).collect();
+        assert_yaml_snapshot!(new_and_updated_events);
+        let _ = fs::remove_dir_all(temp_test_dir.path().join("tests/java"));
+        tree.sync();
+        let deleted_dir_events: Vec<ScanEvent> = tree.scan().map(redact_event).collect();
+        assert_yaml_snapshot!(deleted_dir_events);
+    }
+}

--- a/src/source_hier.rs
+++ b/src/source_hier.rs
@@ -517,10 +517,6 @@ mod test {
             let mut perms = metadata.permissions();
             perms.set_readonly(false);
             fs::set_permissions(&basic_path, perms).unwrap();
-            let basic_file = File::open(&basic_path).unwrap();
-            basic_file
-                .set_modified(SystemTime::now().sub(Duration::from_secs(10)))
-                .unwrap();
         }
         let mut tree = SourceHierTree::from(temp_test_dir.path());
         tree.sync();

--- a/src/source_hier.rs
+++ b/src/source_hier.rs
@@ -513,24 +513,29 @@ mod test {
         let temp_test_dir = setup_test_environment(&tests_path);
         let _ = File::open(temp_test_dir.path().join("tests/java/Basic.java"))
             .unwrap()
-            .set_modified(SystemTime::now().sub(Duration::from_secs(10)));
+            .set_modified(SystemTime::now().sub(Duration::from_secs(10)))
+            .unwrap();
         let mut tree = SourceHierTree::from(temp_test_dir.path());
         tree.sync();
         let events: Vec<ScanEvent> = tree.scan().map(redact_event).collect();
         assert_yaml_snapshot!(events);
         let no_events: Vec<ScanEvent> = tree.scan().map(redact_event).collect();
         assert_yaml_snapshot!(no_events);
-        let _ = fs::remove_file(temp_test_dir.path().join("tests/test_java.rs"));
+        let _ = fs::remove_file(temp_test_dir.path().join("tests/test_java.rs")).unwrap();
         let _ = File::create(temp_test_dir.path().join("new.rs"))
             .unwrap()
-            .write("abc".as_bytes());
-        let _ = File::open(temp_test_dir.path().join("tests/java/Basic.java"))
+            .write("abc".as_bytes())
+            .unwrap();
+        let _ = File::options()
+            .append(true)
+            .open(temp_test_dir.path().join("tests/java/Basic.java"))
             .unwrap()
-            .set_modified(SystemTime::now());
+            .write("def".as_bytes())
+            .unwrap();
         tree.sync();
         let new_and_updated_events: Vec<ScanEvent> = tree.scan().map(redact_event).collect();
         assert_yaml_snapshot!(new_and_updated_events);
-        let _ = fs::remove_dir_all(temp_test_dir.path().join("tests/java"));
+        let _ = fs::remove_dir_all(temp_test_dir.path().join("tests/java")).unwrap();
         tree.sync();
         let deleted_dir_events: Vec<ScanEvent> = tree.scan().map(redact_event).collect();
         assert_yaml_snapshot!(deleted_dir_events);

--- a/src/source_hier.rs
+++ b/src/source_hier.rs
@@ -511,15 +511,16 @@ mod test {
     fn test_with_resources_dir() {
         let tests_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
         let temp_test_dir = setup_test_environment(&tests_path);
+        let basic_path = temp_test_dir.path().join("tests/java/Basic.java");
         {
-            let basic_file = File::open(temp_test_dir.path().join("tests/java/Basic.java"))
-                .unwrap();
-            let metadata = basic_file.metadata().unwrap();
+            let metadata = fs::metadata(&basic_path).unwrap();
             let mut perms = metadata.permissions();
             perms.set_readonly(false);
-            basic_file.set_permissions(perms).unwrap();
-            basic_file.set_modified(SystemTime::now().sub(Duration::from_secs(10)))
-            .unwrap();
+            fs::set_permissions(&basic_path, perms).unwrap();
+            let basic_file = File::open(&basic_path).unwrap();
+            basic_file
+                .set_modified(SystemTime::now().sub(Duration::from_secs(10)))
+                .unwrap();
         }
         let mut tree = SourceHierTree::from(temp_test_dir.path());
         tree.sync();
@@ -534,7 +535,7 @@ mod test {
             .unwrap();
         let _ = File::options()
             .append(true)
-            .open(temp_test_dir.path().join("tests/java/Basic.java"))
+            .open(&basic_path)
             .unwrap()
             .write("def".as_bytes())
             .unwrap();

--- a/src/source_query.rs
+++ b/src/source_query.rs
@@ -22,7 +22,7 @@ impl<'a> SourceQuery<'a> {
     pub fn new(code: &'a CodeSource) -> SourceQuery<'a> {
         // println!("{}", code.filename);
         let mut parser = Parser::new();
-        let language = code.ts_language();
+        let language = code.info.language.into();
         parser
             .set_language(&language)
             .unwrap_or_else(|_| panic!("Error loading {:?} grammar", language));

--- a/src/source_ref.rs
+++ b/src/source_ref.rs
@@ -44,11 +44,11 @@ impl SourceRef {
         }
         let unquoted = &source[start..end].to_string();
         // println!("{} line {}", code.filename, line);
-        if let Some((matcher, pattern, args)) = build_matcher(unquoted, code.language) {
+        if let Some((matcher, pattern, args)) = build_matcher(unquoted, code.info.language) {
             let name = source[result.name_range].to_string();
             Some(SourceRef {
                 source_path: code.filename.clone(),
-                language: code.language,
+                language: code.info.language,
                 line_no: line,
                 column: col,
                 name,

--- a/tests/snapshots/test_rust__invalid_source_path.snap
+++ b/tests/snapshots/test_rust__invalid_source_path.snap
@@ -17,7 +17,7 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-  ⚠ cannot read source file "{example_dir}/stack.r"
+  ⚠ cannot access path "{example_dir}/stack.r"
   ╰─▶ {errmsg} (os error 2)
 
 Error:   × no log statements found


### PR DESCRIPTION
Since lnav is a long-running process, we need to be able to rescan a source tree without repeating a lot of the same work.  This change adds the source_hier module that is a layer that keeps track of the contents of the source hierarchy.  It can detect changes in the files/directories so the caller can be more targeted in figuring out what work to do.  This new module replaces the parts of code_source that did similar work and now CodeSource is mostly used as an intermediate.  Since the CodeSource objects are no longer retained, the problem of keeping all of the source in memory is fixed as well.

Files:
* Cargo.toml: Add itertools for chunks() and some test helpers
* code_source.rs: Remove functions that are obsoleted by source_hier.  Add CodeSource::from_string() method for testing.
* lib.rs: Use source_hier in place of code_source.