### PR TITLE
[source_ref] include the ending line of a log statement

### DIFF
--- a/src/snapshots/log2src__source_hier__test__with_resources_dir-3.snap
+++ b/src/snapshots/log2src__source_hier__test__with_resources_dir-3.snap
@@ -7,12 +7,12 @@ expression: new_and_updated_events
     - 1
 - DeletedFile:
     - test_java.rs
-    - 5
+    - 6
 - NewFile:
     - Basic.java
     - language: Java
-      id: 7
+      id: 8
 - NewFile:
     - new.rs
     - language: Rust
-      id: 8
+      id: 9

--- a/src/snapshots/log2src__source_hier__test__with_resources_dir-4.snap
+++ b/src/snapshots/log2src__source_hier__test__with_resources_dir-4.snap
@@ -4,13 +4,16 @@ expression: deleted_dir_events
 ---
 - DeletedFile:
     - BasicWithUpper.java
-    - 4
+    - 5
 - DeletedFile:
     - BasicWithLog.java
-    - 3
+    - 4
 - DeletedFile:
     - BasicWithCustom.java
+    - 3
+- DeletedFile:
+    - BasicSlf4j.java
     - 2
 - DeletedFile:
     - Basic.java
-    - 7
+    - 8

--- a/src/snapshots/log2src__source_hier__test__with_resources_dir.snap
+++ b/src/snapshots/log2src__source_hier__test__with_resources_dir.snap
@@ -5,21 +5,25 @@ expression: events
 - NewFile:
     - test_rust.rs
     - language: Rust
-      id: 6
+      id: 7
 - NewFile:
     - test_java.rs
     - language: Rust
-      id: 5
+      id: 6
 - NewFile:
     - BasicWithUpper.java
     - language: Java
-      id: 4
+      id: 5
 - NewFile:
     - BasicWithLog.java
     - language: Java
-      id: 3
+      id: 4
 - NewFile:
     - BasicWithCustom.java
+    - language: Java
+      id: 3
+- NewFile:
+    - BasicSlf4j.java
     - language: Java
       id: 2
 - NewFile:

--- a/src/source_ref.rs
+++ b/src/source_ref.rs
@@ -116,7 +116,7 @@ fn build_matcher(
 ) -> Option<(Regex, String, Vec<FormatArgument>)> {
     let mut args = Vec::new();
     let mut last_end = 0;
-    let mut pattern = "^".to_string();
+    let mut pattern = "(?s)^".to_string();
     let mut exact_len = 0;
     for cap in placeholder_regex_for(language).captures_iter(text) {
         let placeholder = cap.get(0).unwrap();
@@ -169,7 +169,7 @@ mod tests {
     fn test_build_matcher_needs_escape() {
         let (matcher, _pat, _args) = build_matcher("{}) {}, {}", SourceLanguage::Rust).unwrap();
         assert_eq!(
-            Regex::new(r#"^(.+)\) (.+), (.+)$"#).unwrap().as_str(),
+            Regex::new(r#"(?s)^(.+)\) (.+), (.+)$"#).unwrap().as_str(),
             matcher.as_str()
         );
     }
@@ -179,7 +179,7 @@ mod tests {
         let (matcher, _pat, _args) =
             build_matcher("abc {main_path:?} def", SourceLanguage::Rust).unwrap();
         assert_eq!(
-            Regex::new(r#"^abc (.+) def$"#).unwrap().as_str(),
+            Regex::new(r#"(?s)^abc (.+) def$"#).unwrap().as_str(),
             matcher.as_str()
         );
     }
@@ -189,7 +189,7 @@ mod tests {
         let (matcher, _pat, args) =
             build_matcher("{}) {:?}, {foo.bar}", SourceLanguage::Rust).unwrap();
         assert_eq!(
-            Regex::new(r#"^(.+)\) (.+), (.+)$"#).unwrap().as_str(),
+            Regex::new(r#"(?s)^(.+)\) (.+), (.+)$"#).unwrap().as_str(),
             matcher.as_str()
         );
         assert_eq!(args[2], FormatArgument::Named("foo.bar".to_string()));
@@ -199,7 +199,7 @@ mod tests {
     fn test_build_matcher_positional() {
         let (matcher, _pat, args) = build_matcher("second={2}", SourceLanguage::Rust).unwrap();
         assert_eq!(
-            Regex::new(r#"^second=(.+)$"#).unwrap().as_str(),
+            Regex::new(r#"(?s)^second=(.+)$"#).unwrap().as_str(),
             matcher.as_str()
         );
         assert_eq!(args[0], FormatArgument::Positional(2));
@@ -210,7 +210,7 @@ mod tests {
         let (matcher, _pat, args) =
             build_matcher("they are %d years old", SourceLanguage::Cpp).unwrap();
         assert_eq!(
-            Regex::new(r#"^they are (.+) years old$"#).unwrap().as_str(),
+            Regex::new(r#"(?s)^they are (.+) years old$"#).unwrap().as_str(),
             matcher.as_str()
         );
         assert_eq!(args[0], FormatArgument::Placeholder);
@@ -221,7 +221,7 @@ mod tests {
         let (matcher, _pat, args) =
             build_matcher("they are {0:d} years old", SourceLanguage::Cpp).unwrap();
         assert_eq!(
-            Regex::new(r#"^they are (.+) years old$"#).unwrap().as_str(),
+            Regex::new(r#"(?s)^they are (.+) years old$"#).unwrap().as_str(),
             matcher.as_str()
         );
         assert_eq!(args[0], FormatArgument::Positional(0));
@@ -241,7 +241,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            Regex::new(r#"^you're only as funky\n as your last cut$"#)
+            Regex::new(r#"(?s)^you're only as funky\n as your last cut$"#)
                 .unwrap()
                 .as_str(),
             matcher.as_str()

--- a/src/source_ref.rs
+++ b/src/source_ref.rs
@@ -20,6 +20,8 @@ pub struct SourceRef {
     pub language: SourceLanguage,
     #[serde(rename(serialize = "lineNumber"))]
     pub line_no: usize,
+    #[serde(rename(serialize = "endLineNumber"))]
+    pub end_line_no: usize,
     pub column: usize,
     pub name: String,
     pub text: String,
@@ -35,7 +37,8 @@ impl SourceRef {
         let range = result.range;
         let source = code.buffer.as_str();
         let text = source[range.start_byte..range.end_byte].to_string();
-        let line = range.start_point.row + 1;
+        let line_no = range.start_point.row + 1;
+        let end_line_no = range.end_point.row + 1;
         let col = range.start_point.column;
         let start = range.start_byte + 1;
         let mut end = range.end_byte - 1;
@@ -49,7 +52,8 @@ impl SourceRef {
             Some(SourceRef {
                 source_path: code.filename.clone(),
                 language: code.info.language,
-                line_no: line,
+                line_no,
+                end_line_no,
                 column: col,
                 name,
                 text,
@@ -93,7 +97,7 @@ static RUST_PLACEHOLDER_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 });
 
 static JAVA_PLACEHOLDER_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"\\?\{.*}"#).unwrap());
+    LazyLock::new(|| Regex::new(r#"\{.*}|\\\{(.*)}"#).unwrap());
 
 static CPP_PLACEHOLDER_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"%[-+ #0]*\d*(?:\.\d+)?[hlLzjt]*[diuoxXfFeEgGaAcspn%]|\{(?:([a-zA-Z_][a-zA-Z0-9_.]*)|(\d+))?\s*(?::[^}]*)?}"#).unwrap());

--- a/tests/java/BasicSlf4j.java
+++ b/tests/java/BasicSlf4j.java
@@ -1,0 +1,15 @@
+package org.example;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Main {
+    private static final Logger logger = LoggerFactory.getLogger(Main.class);
+
+    public static void main(String[] args) throws InterruptedException {
+        logger.info("Application starting");
+
+        logger.debug("Debug message: args length = {}",
+                     args.length);
+    }
+}

--- a/tests/resources/java/basic-slf4j.log
+++ b/tests/resources/java/basic-slf4j.log
@@ -1,0 +1,2 @@
+2024-05-08 14:46:47 Application starting
+2024-05-08 14:46:47 Debug message: args length = 0

--- a/tests/snapshots/test_java__basic.snap
+++ b/tests/snapshots/test_java__basic.snap
@@ -13,9 +13,9 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-{"srcRef":{"sourcePath":"{java_dir}/Basic.java","language":"Java","lineNumber":18,"column":16,"name":"main","text":"\"Hello from main\"","pattern":"^Hello from main$","args":[],"vars":[]},"variables":[]}
-{"srcRef":{"sourcePath":"{java_dir}/Basic.java","language":"Java","lineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"0"}]}
-{"srcRef":{"sourcePath":"{java_dir}/Basic.java","language":"Java","lineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"1"}]}
-{"srcRef":{"sourcePath":"{java_dir}/Basic.java","language":"Java","lineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"2"}]}
+{"srcRef":{"sourcePath":"{java_dir}/Basic.java","language":"Java","lineNumber":18,"endLineNumber":18,"column":16,"name":"main","text":"\"Hello from main\"","pattern":"^Hello from main$","args":[],"vars":[]},"variables":[]}
+{"srcRef":{"sourcePath":"{java_dir}/Basic.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"0"}]}
+{"srcRef":{"sourcePath":"{java_dir}/Basic.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"1"}]}
+{"srcRef":{"sourcePath":"{java_dir}/Basic.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"2"}]}
 
 ----- stderr -----

--- a/tests/snapshots/test_java__basic.snap
+++ b/tests/snapshots/test_java__basic.snap
@@ -13,9 +13,9 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-{"srcRef":{"sourcePath":"{java_dir}/Basic.java","language":"Java","lineNumber":18,"endLineNumber":18,"column":16,"name":"main","text":"\"Hello from main\"","pattern":"^Hello from main$","args":[],"vars":[]},"variables":[]}
-{"srcRef":{"sourcePath":"{java_dir}/Basic.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"0"}]}
-{"srcRef":{"sourcePath":"{java_dir}/Basic.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"1"}]}
-{"srcRef":{"sourcePath":"{java_dir}/Basic.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"2"}]}
+{"srcRef":{"sourcePath":"{java_dir}/Basic.java","language":"Java","lineNumber":18,"endLineNumber":18,"column":16,"name":"main","text":"\"Hello from main\"","pattern":"(?s)^Hello from main$","args":[],"vars":[]},"variables":[]}
+{"srcRef":{"sourcePath":"{java_dir}/Basic.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"(?s)^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"0"}]}
+{"srcRef":{"sourcePath":"{java_dir}/Basic.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"(?s)^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"1"}]}
+{"srcRef":{"sourcePath":"{java_dir}/Basic.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"(?s)^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"2"}]}
 
 ----- stderr -----

--- a/tests/snapshots/test_java__basic_slf4j.snap
+++ b/tests/snapshots/test_java__basic_slf4j.snap
@@ -13,7 +13,7 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-{"srcRef":{"sourcePath":"{java_dir}/BasicSlf4j.java","language":"Java","lineNumber":10,"endLineNumber":10,"column":20,"name":"main","text":"\"Application starting\"","pattern":"^Application starting$","args":[],"vars":[]},"variables":[]}
-{"srcRef":{"sourcePath":"{java_dir}/BasicSlf4j.java","language":"Java","lineNumber":12,"endLineNumber":13,"column":21,"name":"main","text":"\"Debug message: args length = {}\"","pattern":"^Debug message: args length = (.+)$","args":["Placeholder"],"vars":["args.length"]},"variables":[{"expr":"args.length","value":"0"}]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicSlf4j.java","language":"Java","lineNumber":10,"endLineNumber":10,"column":20,"name":"main","text":"\"Application starting\"","pattern":"(?s)^Application starting$","args":[],"vars":[]},"variables":[]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicSlf4j.java","language":"Java","lineNumber":12,"endLineNumber":13,"column":21,"name":"main","text":"\"Debug message: args length = {}\"","pattern":"(?s)^Debug message: args length = (.+)$","args":["Placeholder"],"vars":["args.length"]},"variables":[{"expr":"args.length","value":"0"}]}
 
 ----- stderr -----

--- a/tests/snapshots/test_java__basic_slf4j.snap
+++ b/tests/snapshots/test_java__basic_slf4j.snap
@@ -1,0 +1,19 @@
+---
+source: tests/test_java.rs
+info:
+  program: log2src
+  args:
+    - "-d"
+    - tests/java/BasicSlf4j.java
+    - "-l"
+    - tests/resources/java/basic-slf4j.log
+    - "-f"
+    - "^(?<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}) (?<body>.*)$"
+---
+success: true
+exit_code: 0
+----- stdout -----
+{"srcRef":{"sourcePath":"{java_dir}/BasicSlf4j.java","language":"Java","lineNumber":10,"endLineNumber":10,"column":20,"name":"main","text":"\"Application starting\"","pattern":"^Application starting$","args":[],"vars":[]},"variables":[]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicSlf4j.java","language":"Java","lineNumber":12,"endLineNumber":13,"column":21,"name":"main","text":"\"Debug message: args length = {}\"","pattern":"^Debug message: args length = (.+)$","args":["Placeholder"],"vars":["args.length"]},"variables":[{"expr":"args.length","value":"0"}]}
+
+----- stderr -----

--- a/tests/snapshots/test_java__basic_with_log.snap
+++ b/tests/snapshots/test_java__basic_with_log.snap
@@ -13,9 +13,9 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithLog.java","language":"Java","lineNumber":18,"endLineNumber":18,"column":13,"name":"main","text":"\"Hello from main\"","pattern":"^Hello from main$","args":[],"vars":[]},"variables":[]}
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithLog.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":17,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"0"}]}
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithLog.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":17,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"1"}]}
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithLog.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":17,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"2"}]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithLog.java","language":"Java","lineNumber":18,"endLineNumber":18,"column":13,"name":"main","text":"\"Hello from main\"","pattern":"(?s)^Hello from main$","args":[],"vars":[]},"variables":[]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithLog.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":17,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"(?s)^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"0"}]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithLog.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":17,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"(?s)^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"1"}]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithLog.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":17,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"(?s)^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"2"}]}
 
 ----- stderr -----

--- a/tests/snapshots/test_java__basic_with_log.snap
+++ b/tests/snapshots/test_java__basic_with_log.snap
@@ -13,9 +13,9 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithLog.java","language":"Java","lineNumber":18,"column":13,"name":"main","text":"\"Hello from main\"","pattern":"^Hello from main$","args":[],"vars":[]},"variables":[]}
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithLog.java","language":"Java","lineNumber":25,"column":17,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"0"}]}
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithLog.java","language":"Java","lineNumber":25,"column":17,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"1"}]}
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithLog.java","language":"Java","lineNumber":25,"column":17,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"2"}]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithLog.java","language":"Java","lineNumber":18,"endLineNumber":18,"column":13,"name":"main","text":"\"Hello from main\"","pattern":"^Hello from main$","args":[],"vars":[]},"variables":[]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithLog.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":17,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"0"}]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithLog.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":17,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"1"}]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithLog.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":17,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"2"}]}
 
 ----- stderr -----

--- a/tests/snapshots/test_java__basic_with_log_format.snap
+++ b/tests/snapshots/test_java__basic_with_log_format.snap
@@ -13,9 +13,9 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithCustom.java","language":"Java","lineNumber":15,"column":16,"name":"main","text":"\"Hello from main\"","pattern":"^Hello from main$","args":[],"vars":[]},"variables":[]}
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithCustom.java","language":"Java","lineNumber":22,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"0"}]}
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithCustom.java","language":"Java","lineNumber":22,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"1"}]}
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithCustom.java","language":"Java","lineNumber":22,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"2"}]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithCustom.java","language":"Java","lineNumber":15,"endLineNumber":15,"column":16,"name":"main","text":"\"Hello from main\"","pattern":"^Hello from main$","args":[],"vars":[]},"variables":[]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithCustom.java","language":"Java","lineNumber":22,"endLineNumber":22,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"0"}]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithCustom.java","language":"Java","lineNumber":22,"endLineNumber":22,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"1"}]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithCustom.java","language":"Java","lineNumber":22,"endLineNumber":22,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"2"}]}
 
 ----- stderr -----

--- a/tests/snapshots/test_java__basic_with_log_format.snap
+++ b/tests/snapshots/test_java__basic_with_log_format.snap
@@ -13,9 +13,9 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithCustom.java","language":"Java","lineNumber":15,"endLineNumber":15,"column":16,"name":"main","text":"\"Hello from main\"","pattern":"^Hello from main$","args":[],"vars":[]},"variables":[]}
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithCustom.java","language":"Java","lineNumber":22,"endLineNumber":22,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"0"}]}
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithCustom.java","language":"Java","lineNumber":22,"endLineNumber":22,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"1"}]}
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithCustom.java","language":"Java","lineNumber":22,"endLineNumber":22,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"2"}]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithCustom.java","language":"Java","lineNumber":15,"endLineNumber":15,"column":16,"name":"main","text":"\"Hello from main\"","pattern":"(?s)^Hello from main$","args":[],"vars":[]},"variables":[]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithCustom.java","language":"Java","lineNumber":22,"endLineNumber":22,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"(?s)^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"0"}]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithCustom.java","language":"Java","lineNumber":22,"endLineNumber":22,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"(?s)^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"1"}]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithCustom.java","language":"Java","lineNumber":22,"endLineNumber":22,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"(?s)^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"2"}]}
 
 ----- stderr -----

--- a/tests/snapshots/test_java__basic_with_upper.snap
+++ b/tests/snapshots/test_java__basic_with_upper.snap
@@ -13,9 +13,9 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithUpper.java","language":"Java","lineNumber":18,"column":16,"name":"main","text":"\"Hello from main\"","pattern":"^Hello from main$","args":[],"vars":[]},"variables":[]}
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithUpper.java","language":"Java","lineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"0"}]}
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithUpper.java","language":"Java","lineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"1"}]}
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithUpper.java","language":"Java","lineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"2"}]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithUpper.java","language":"Java","lineNumber":18,"endLineNumber":18,"column":16,"name":"main","text":"\"Hello from main\"","pattern":"^Hello from main$","args":[],"vars":[]},"variables":[]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithUpper.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"0"}]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithUpper.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"1"}]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithUpper.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"2"}]}
 
 ----- stderr -----

--- a/tests/snapshots/test_java__basic_with_upper.snap
+++ b/tests/snapshots/test_java__basic_with_upper.snap
@@ -13,9 +13,9 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithUpper.java","language":"Java","lineNumber":18,"endLineNumber":18,"column":16,"name":"main","text":"\"Hello from main\"","pattern":"^Hello from main$","args":[],"vars":[]},"variables":[]}
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithUpper.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"0"}]}
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithUpper.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"1"}]}
-{"srcRef":{"sourcePath":"{java_dir}/BasicWithUpper.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"2"}]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithUpper.java","language":"Java","lineNumber":18,"endLineNumber":18,"column":16,"name":"main","text":"\"Hello from main\"","pattern":"(?s)^Hello from main$","args":[],"vars":[]},"variables":[]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithUpper.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"(?s)^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"0"}]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithUpper.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"(?s)^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"1"}]}
+{"srcRef":{"sourcePath":"{java_dir}/BasicWithUpper.java","language":"Java","lineNumber":25,"endLineNumber":25,"column":20,"name":"foo","text":"\"Hello from foo i=\\{i}\"","pattern":"(?s)^Hello from foo i=(.+)$","args":[{"Named":"i"}],"vars":[]},"variables":[{"expr":"i","value":"2"}]}
 
 ----- stderr -----

--- a/tests/snapshots/test_rust__basic.snap
+++ b/tests/snapshots/test_rust__basic.snap
@@ -13,11 +13,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":6,"endLineNumber":6,"column":11,"name":"main","text":"\"Hello from main\"","pattern":"^Hello from main$","args":[],"vars":[]},"variables":[]}
-{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":15,"endLineNumber":15,"column":11,"name":"foo","text":"\"Hello from foo i={}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"0"}]}
-{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":15,"endLineNumber":15,"column":11,"name":"foo","text":"\"Hello from foo i={}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"1"}]}
-{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":15,"endLineNumber":15,"column":11,"name":"foo","text":"\"Hello from foo i={}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"2"}]}
-{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":18,"endLineNumber":18,"column":24,"name":"bar","text":"\"Hello from bar j={j}\"","pattern":"^Hello from bar j=(.+)$","args":[{"Named":"j"}],"vars":[]},"variables":[{"expr":"j","value":"4"}]}
-{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":20,"endLineNumber":20,"column":32,"name":"baz","text":"\"Hello from baz i={1} j={0}\"","pattern":"^Hello from baz i=(.+) j=(.+)$","args":[{"Positional":1},{"Positional":0}],"vars":["j","i"]},"variables":[{"expr":"i","value":"5"},{"expr":"j","value":"6"}]}
+{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":6,"endLineNumber":6,"column":11,"name":"main","text":"\"Hello from main\"","pattern":"(?s)^Hello from main$","args":[],"vars":[]},"variables":[]}
+{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":15,"endLineNumber":15,"column":11,"name":"foo","text":"\"Hello from foo i={}\"","pattern":"(?s)^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"0"}]}
+{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":15,"endLineNumber":15,"column":11,"name":"foo","text":"\"Hello from foo i={}\"","pattern":"(?s)^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"1"}]}
+{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":15,"endLineNumber":15,"column":11,"name":"foo","text":"\"Hello from foo i={}\"","pattern":"(?s)^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"2"}]}
+{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":18,"endLineNumber":18,"column":24,"name":"bar","text":"\"Hello from bar j={j}\"","pattern":"(?s)^Hello from bar j=(.+)$","args":[{"Named":"j"}],"vars":[]},"variables":[{"expr":"j","value":"4"}]}
+{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":20,"endLineNumber":20,"column":32,"name":"baz","text":"\"Hello from baz i={1} j={0}\"","pattern":"(?s)^Hello from baz i=(.+) j=(.+)$","args":[{"Positional":1},{"Positional":0}],"vars":["j","i"]},"variables":[{"expr":"i","value":"5"},{"expr":"j","value":"6"}]}
 
 ----- stderr -----

--- a/tests/snapshots/test_rust__basic.snap
+++ b/tests/snapshots/test_rust__basic.snap
@@ -13,11 +13,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":6,"column":11,"name":"main","text":"\"Hello from main\"","pattern":"^Hello from main$","args":[],"vars":[]},"variables":[]}
-{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":15,"column":11,"name":"foo","text":"\"Hello from foo i={}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"0"}]}
-{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":15,"column":11,"name":"foo","text":"\"Hello from foo i={}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"1"}]}
-{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":15,"column":11,"name":"foo","text":"\"Hello from foo i={}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"2"}]}
-{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":18,"column":24,"name":"bar","text":"\"Hello from bar j={j}\"","pattern":"^Hello from bar j=(.+)$","args":[{"Named":"j"}],"vars":[]},"variables":[{"expr":"j","value":"4"}]}
-{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":20,"column":32,"name":"baz","text":"\"Hello from baz i={1} j={0}\"","pattern":"^Hello from baz i=(.+) j=(.+)$","args":[{"Positional":1},{"Positional":0}],"vars":["j","i"]},"variables":[{"expr":"i","value":"5"},{"expr":"j","value":"6"}]}
+{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":6,"endLineNumber":6,"column":11,"name":"main","text":"\"Hello from main\"","pattern":"^Hello from main$","args":[],"vars":[]},"variables":[]}
+{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":15,"endLineNumber":15,"column":11,"name":"foo","text":"\"Hello from foo i={}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"0"}]}
+{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":15,"endLineNumber":15,"column":11,"name":"foo","text":"\"Hello from foo i={}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"1"}]}
+{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":15,"endLineNumber":15,"column":11,"name":"foo","text":"\"Hello from foo i={}\"","pattern":"^Hello from foo i=(.+)$","args":["Placeholder"],"vars":["i"]},"variables":[{"expr":"i","value":"2"}]}
+{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":18,"endLineNumber":18,"column":24,"name":"bar","text":"\"Hello from bar j={j}\"","pattern":"^Hello from bar j=(.+)$","args":[{"Named":"j"}],"vars":[]},"variables":[{"expr":"j","value":"4"}]}
+{"srcRef":{"sourcePath":"{example_dir}/basic.rs","language":"Rust","lineNumber":20,"endLineNumber":20,"column":32,"name":"baz","text":"\"Hello from baz i={1} j={0}\"","pattern":"^Hello from baz i=(.+) j=(.+)$","args":[{"Positional":1},{"Positional":0}],"vars":["j","i"]},"variables":[{"expr":"i","value":"5"},{"expr":"j","value":"6"}]}
 
 ----- stderr -----

--- a/tests/snapshots/test_rust__stack.snap
+++ b/tests/snapshots/test_rust__stack.snap
@@ -15,6 +15,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-{"srcRef":{"sourcePath":"{example_dir}/stack.rs","language":"Rust","lineNumber":15,"endLineNumber":15,"column":11,"name":"b","text":"\"Hello from b\"","pattern":"^Hello from b$","args":[],"vars":[]},"variables":[]}
+{"srcRef":{"sourcePath":"{example_dir}/stack.rs","language":"Rust","lineNumber":15,"endLineNumber":15,"column":11,"name":"b","text":"\"Hello from b\"","pattern":"(?s)^Hello from b$","args":[],"vars":[]},"variables":[]}
 
 ----- stderr -----

--- a/tests/snapshots/test_rust__stack.snap
+++ b/tests/snapshots/test_rust__stack.snap
@@ -15,6 +15,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-{"srcRef":{"sourcePath":"{example_dir}/stack.rs","language":"Rust","lineNumber":15,"column":11,"name":"b","text":"\"Hello from b\"","pattern":"^Hello from b$","args":[],"vars":[]},"variables":[]}
+{"srcRef":{"sourcePath":"{example_dir}/stack.rs","language":"Rust","lineNumber":15,"endLineNumber":15,"column":11,"name":"b","text":"\"Hello from b\"","pattern":"^Hello from b$","args":[],"vars":[]},"variables":[]}
 
 ----- stderr -----

--- a/tests/test_java.rs
+++ b/tests/test_java.rs
@@ -83,3 +83,23 @@ fn basic_with_log_format() -> Result<(), Box<dyn std::error::Error>> {
     assert_cmd_snapshot!(cmd);
     Ok(())
 }
+
+#[test]
+fn basic_slf4j() -> Result<(), Box<dyn std::error::Error>> {
+    let _guard = common_settings::enable_filters();
+    let mut cmd = Command::cargo_bin("log2src")?;
+    let source = Path::new("tests").join("java").join("BasicSlf4j.java");
+    let log = Path::new("tests")
+        .join("resources")
+        .join("java")
+        .join("basic-slf4j.log");
+    cmd.arg("-d")
+        .arg(source.to_str().expect("test case source code exists"))
+        .arg("-l")
+        .arg(log.to_str().expect("test case log exists"))
+        .arg("-f")
+        .arg("^(?<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}) (?<body>.*)$");
+
+    assert_cmd_snapshot!(cmd);
+    Ok(())
+}


### PR DESCRIPTION
If a log statement is broken up over multiple lines, the user might refer to any of those lines when setting a breakpoint.  So, we need to include the ending line number in the SourceRef.

Files:
* lib.rs: Add a method to get the StatementsInFile object from the LogMatcher.  This is needed to handle a breakpoint request.  Also, adjust the java tree-sitter query so template strings are handled using Named placeholders.
* source_hier.rs: Completely ignore some directories in the source hierarchy, like version control ones.  Add methods to find a file in the source hierarchy.
* source_query.rs: Only return results from captures after the format string.
* source_ref.rs: Add ending line number.
* test_java.rs: Add a java test that uses slf4j-style log statements.