### PR TITLE
[progress] add support for polling the ProgressListener with a timeout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub use code_source::CodeSource;
 use log_format::LogFormat;
 pub use progress::ProgressTracker;
 pub use progress::ProgressUpdate;
+pub use progress::WorkInfo;
 use source_query::QueryResult;
 pub use source_query::SourceQuery;
 pub use source_ref::SourceRef;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Arc;
+use std::time::Duration;
 
 pub struct WorkInfo {
     pub completed: AtomicU64,
@@ -115,5 +116,11 @@ impl Iterator for ProgressListener {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.receiver.iter().next()
+    }
+}
+
+impl ProgressListener {
+    pub fn try_next_for(&self, timeout: Duration) -> Option<ProgressUpdate> {
+        self.receiver.recv_timeout(timeout).ok()
     }
 }


### PR DESCRIPTION
There's a thread in lnav that needs to poll for
progress and can't block waiting for an update.