### PR TITLE
[stacktrace] pull file/line/name out of stack traces

### DIFF
--- a/editors/code/src/debugAdapter.ts
+++ b/editors/code/src/debugAdapter.ts
@@ -19,9 +19,15 @@ import * as path from 'path';
 
 import { outputChannel } from './extension';
 
+interface CallSite {
+    name: string,
+    sourcePath: string,
+    lineNumber: number
+}
 
 interface LogMapping {
     srcRef: SourceRef,
+    exceptionTrace: Array<CallSite>,
     variables: Array<VariablePair>
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,16 +143,15 @@ impl LogMatcher {
     }
 
     pub fn find_source_file_statements(&self, path: &Path) -> Vec<&StatementsInFile> {
-        let mut retval: Vec<&StatementsInFile> = Vec::new();
-        self.roots.values().for_each(|root| {
-            retval.extend(
+        self.roots
+            .values()
+            .flat_map(|root| {
                 root.tree
                     .find_file(path)
-                    .iter()
-                    .filter_map(|(_actual_path, info)| root.files_with_statements.get(&info.id)),
-            );
-        });
-        retval
+                    .into_iter()
+                    .filter_map(|(_actual_path, info)| root.files_with_statements.get(&info.id))
+            })
+            .collect()
     }
 
     /// Traverse the roots looking for supported source files.

--- a/src/snapshots/log2src__tests__python_trace.snap
+++ b/src/snapshots/log2src__tests__python_trace.snap
@@ -1,0 +1,12 @@
+---
+source: src/lib.rs
+expression: trace
+---
+- name: main
+  sourcePath: python-logging-example/python_logging_example/__main__.py
+  language: Python
+  lineNumber: 26
+- name: fail_now
+  sourcePath: python-logging-example/python_logging_example/helper.py
+  language: Python
+  lineNumber: 3

--- a/src/source_ref.rs
+++ b/src/source_ref.rs
@@ -11,6 +11,16 @@ pub enum FormatArgument {
     Placeholder,
 }
 
+#[derive(Clone, Debug, Serialize)]
+pub struct CallSite {
+    pub name: String,
+    #[serde(rename(serialize = "sourcePath"))]
+    pub source_path: String,
+    pub language: SourceLanguage,
+    #[serde(rename(serialize = "lineNumber"))]
+    pub line_no: usize,
+}
+
 // TODO: get rid of this clone?
 #[derive(Clone, Debug, Serialize)]
 pub struct SourceRef {


### PR DESCRIPTION
The previous change just pulled out the entire stack trace from the log message.  This change processes the stack traces to pull out the file/line/name
data.

Note: I haven't standardized an order for the call sites in a trace, Java goes one way and Python goes the other.  Sigh...

Files:
* debugAdapter.ts: Add exceptionTrace field to LogMapping.
* lib.rs: The find_source_file_statements() can now match multiple source files since find_file() can now match multiple files.  Add exception_trace to LogMapping and to_exception_trace() to StackTrace.
* main.rs: Change the meaning of --count to be the number of messages since we don't necessarily know how many lines are in a message.
* source_hier.rs: Since the Java stack trace code can only figure out the package and class name. The find_file() method has been changed to allow searching the tree for a partial path.  For example, searching for "org/example/Main.java" will walk the entire tree looking for a match of that path.  It will then return all possible matches of that path.